### PR TITLE
Tags with no matching Jira issue should be ignored

### DIFF
--- a/src/main/java/io/wisetime/connector/jira/JiraConnector.java
+++ b/src/main/java/io/wisetime/connector/jira/JiraConnector.java
@@ -132,6 +132,14 @@ public class JiraConnector implements WiseTimeConnector {
           .withMessage("User does not exist in Jira");
     }
 
+    final Function<Tag, Optional<Issue>> findIssue = tag -> {
+      final Optional<Issue> issue = jiraDao.findIssueByTagName(tag.getName());
+      if (!issue.isPresent()) {
+        log.warn("Can't find Jira issue for tag {}. No time will be posted for this tag.", tag.getName());
+      }
+      return issue;
+    };
+
     final long workedTime = Math.round(tagDuration(userPostedTime));
 
     final Function<Issue, Issue> updateIssueTimeSpent = issue -> {
@@ -160,8 +168,7 @@ public class JiraConnector implements WiseTimeConnector {
               .getTags()
               .stream()
 
-              .map(Tag::getName)
-              .map(jiraDao::findIssueByTagName)
+              .map(findIssue)
               .filter(Optional::isPresent)
               .map(Optional::get)
 

--- a/src/main/java/io/wisetime/connector/jira/JiraConnector.java
+++ b/src/main/java/io/wisetime/connector/jira/JiraConnector.java
@@ -162,8 +162,7 @@ public class JiraConnector implements WiseTimeConnector {
 
               .map(Tag::getName)
               .map(jiraDao::findIssueByTagName)
-
-              // Fail the transaction if one of the tags doesn't have a matching issue
+              .filter(Optional::isPresent)
               .map(Optional::get)
 
               .map(updateIssueTimeSpent)


### PR DESCRIPTION
A team might have more than one webhook/integration. In that scenario, we still send all posted time groups to all webhooks and let them decide whether they can handle the posted time.

Instead of failing the time group, ignore tags that don't have matching Jira issues.

FYI @alvinllobrera, @pfilippi24, @chanddan.